### PR TITLE
feat: add support for Node.js v10, v12, and v14

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,27 @@
+name: nodejs
+on: [pull_request, push]
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [10, 12, 14]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+    - name: Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2.0.0
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Update npm
+      run: |
+        npm install -g npm
+        npm --version
+    - uses: actions/checkout@v2.3.1
+    - name: Install dependencies
+      uses: bahmutov/npm-install@v1.4.1
+      with:
+        useLockFile: false
+    - name: npm ls
+      run: npm ls
+    - name: Test
+      run: npm test

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-node_js:
-  - '4'
-  - '5'
-  - '6'
-sudo: false
-before_install:
-  - npm install -g npm
-  - npm --version

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # birth-by-age-at-date
 
-[![Build Status](https://travis-ci.org/KenanY/birth-by-age-at-date.svg?branch=master)](https://travis-ci.org/KenanY/birth-by-age-at-date)
-[![Dependency Status](https://gemnasium.com/KenanY/birth-by-age-at-date.svg)](https://gemnasium.com/KenanY/birth-by-age-at-date)
-
 Calculates the birth year and current age based on the age as of a date. Based
 off, believe it or not, Wikipedia's
 [Template:Birth_based_on_age_as_of_date](https://en.wikipedia.org/wiki/Template:Birth_based_on_age_as_of_date).

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   "repository": "KenanY/birth-by-age-at-date",
   "license": "MIT",
   "author": "Kenan Yildirim <kenan@kenany.me> (http://kenany.me/)",
+  "engines": {
+    "node": "10 || 12 || >=14"
+  },
   "main": "index.js",
   "files": [
     "index.js",
@@ -18,8 +21,7 @@
   },
   "scripts": {
     "pretest": "eslint index.js test/index.js",
-    "test": "tape test/index.js",
-    "posttest": "nsp check"
+    "test": "tape test/index.js"
   },
   "dependencies": {
     "day-of-year": "^0.1.0",
@@ -29,7 +31,6 @@
   "devDependencies": {
     "@kenan/eslint-config": "^2.0.0",
     "eslint": "^3.3.0",
-    "nsp": "^2.4.0",
     "tape": "^4.4.0"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: The minimum supported version of Node.js is now v10.