### PR TITLE
feat: drop Node.js v10 support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10, 12, 14]
+        node-version: [12, 14, 16]
         os: [ubuntu-latest]
     steps:
     - name: Node.js ${{ matrix.node-version }}
@@ -25,5 +25,3 @@ jobs:
       run: npm ls
     - name: Test
       run: npm test
-    - name: Lint
-      run: npm run lint

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2014–2016 Kenan Yildirim <http://kenany.me/>
+Copyright 2014–2021 Kenan Yildirim <https://kenany.me/>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ individual was _Number_ `age` at _Date_ `date`. Returns an `Object`:
   - `.upperAge` (may be `undefined`)
 
 There will always be two possible birth years: `.lowerYear` and `.upperYear`.
-`.upperAge` will _not_ appear if the number of days elasped in `date`'s year is
-equal to the number of days elasped in `currentDate`'s year.
+`.upperAge` will _not_ appear if the number of days elapsed in `date`'s year is
+equal to the number of days elapsed in `currentDate`'s year.
 
 By default, `new Date()` is used to calculate current age. You can optionally
 pass your own `currentDate` as a third argument.

--- a/index.js
+++ b/index.js
@@ -1,13 +1,18 @@
 var isDate = require('lodash.isdate');
 var daysElapsed = require('day-of-year');
 
+/**
+ * @param {number} age
+ * @param {Date} date
+ * @param {Date} [currentDate]
+ */
 function birthByAgeAtDate(age, date, currentDate) {
   if (!isDate(date)) {
-    return new TypeError('`date` must be a Date');
+    throw new TypeError('`date` must be a Date');
   }
 
   if (currentDate && !isDate(currentDate)) {
-    return new TypeError('`currentDate` must be a Date');
+    throw new TypeError('`currentDate` must be a Date');
   }
 
   if (!currentDate) {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   ],
   "repository": "KenanY/birth-by-age-at-date",
   "license": "MIT",
-  "author": "Kenan Yildirim <kenan@kenany.me> (http://kenany.me/)",
+  "author": "Kenan Yildirim <kenan@kenany.me> (https://kenany.me/)",
   "engines": {
-    "node": "10 || 12 || >=14"
+    "node": "12 || 14 || >=16"
   },
   "main": "index.js",
   "files": [
@@ -20,9 +20,14 @@
     "test": "test"
   },
   "scripts": {
+    "type-check": "tsc",
+    "posttype-check": "npm run -s type-coverage",
+    "type-coverage": "type-coverage --at-least 100 --detail --strict",
     "lint": "eslint index.js test/index.js",
     "release": "semantic-release",
-    "test": "tape test/index.js"
+    "pretest": "npm run -s type-check",
+    "test": "tape test/index.js",
+    "posttest": "npm run -s lint"
   },
   "dependencies": {
     "day-of-year": "^0.1.0",
@@ -33,9 +38,14 @@
     "@kenan/renovate-config": "^1.5.1",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
+    "@tsconfig/node12": "^1.0.9",
+    "@types/lodash.isdate": "^4.0.6",
+    "@types/tape": "^4.13.2",
     "conventional-changelog-conventionalcommits": "^4.6.1",
     "eslint": "^7.32.0",
     "semantic-release": "^18.0.0",
-    "tape": "^5.3.1"
+    "tape": "^5.3.1",
+    "type-coverage": "^2.19.0",
+    "typescript": "^4.5.4"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,49 +1,80 @@
-var test = require('tape');
-var birth = require('../');
+const test = require('tape');
+const birth = require('../');
 
-var now = new Date(2014, 3, 17);
+const now = new Date(2014, 3, 17);
 
-test('returns TypeError when date is not a Date', function(t) {
+/**
+ * @param {Error} error
+ * @returns {error is TypeError}
+ */
+function isTypeError(error) {
+  return error instanceof TypeError;
+}
+
+test('throws TypeError when date is not a Date', function(t) {
   t.plan(5);
-  t.ok(birth(50) instanceof TypeError);
-  t.ok(birth(50, {}) instanceof TypeError);
-  t.ok(birth(50, '2013-03-17') instanceof TypeError);
-  t.ok(birth(50, [2013, 3, 17]) instanceof TypeError);
-  t.ok(birth(50, 2013) instanceof TypeError);
+
+  // @ts-expect-error
+  t.throws(() => birth(50), isTypeError);
+
+  // @ts-expect-error
+  t.throws(() => birth(50, {}), isTypeError);
+
+  // @ts-expect-error
+  t.throws(() => birth(50, '2013-03-17'), isTypeError);
+
+  // @ts-expect-error
+  t.throws(() => birth(50, [2013, 3, 17]), isTypeError);
+
+  // @ts-expect-error
+  t.throws(() => birth(50, 2013), isTypeError);
 });
 
 test('returns TypeError when currentDate is not a Date', function(t) {
   t.plan(4);
-  t.ok(birth(50, new Date(2013, 2, 17), {}) instanceof TypeError);
-  t.ok(birth(50, new Date(2013, 2, 17), '2013-03-17') instanceof TypeError);
-  t.ok(birth(50, new Date(2013, 2, 17), [2013, 3, 17]) instanceof TypeError);
-  t.ok(birth(50, new Date(2013, 2, 17), 2013, 3, 17) instanceof TypeError);
+
+  // @ts-expect-error
+  t.throws(() => birth(50, new Date(2013, 2, 17), {}), isTypeError);
+
+  // @ts-expect-error
+  t.throws(() => birth(50, new Date(2013, 2, 17), '2013-03-17'), isTypeError);
+
+  // @ts-expect-error
+  t.throws(() => birth(50, new Date(2013, 2, 17), [2013, 3, 17]), isTypeError);
+
+  // @ts-expect-error
+  t.throws(() => birth(50, new Date(2013, 2, 17), 2013, 3, 17), isTypeError);
 });
 
 test('works', function(t) {
-  var TEST_ARRAY = [
-    [[50, new Date(2013, 3, 17), now], {
+  t.plan(3);
+
+  t.deepEquals(
+    birth(50, new Date(2013, 3, 17), now),
+    {
       lowerYear: 1962,
       upperYear: 1963,
       lowerAge: 51
-    }],
-    [[50, new Date(2013, 0, 15), now], {
+    }
+  );
+
+  t.deepEquals(
+    birth(50, new Date(2013, 0, 15), now),
+    {
       lowerYear: 1962,
       upperYear: 1963,
       lowerAge: 51,
       upperAge: 52
-    }],
-    [[50, new Date(2013, 10, 5), now], {
+    }
+  );
+
+  t.deepEquals(
+    birth(50, new Date(2013, 10, 5), now),
+    {
       lowerYear: 1962,
       upperYear: 1963,
       lowerAge: 50,
       upperAge: 51
-    }]
-  ];
-
-  t.plan(TEST_ARRAY.length);
-
-  TEST_ARRAY.forEach(function(entry) {
-    t.deepEquals(birth(entry[0][0], entry[0][1], entry[0][2]), entry[1]);
-  });
+    }
+  );
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@tsconfig/node12/tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": ["typings/", "*.js", "test/**/*.js"]
+}

--- a/typings/day-of-year.d.ts
+++ b/typings/day-of-year.d.ts
@@ -1,0 +1,4 @@
+declare module 'day-of-year' {
+  function dayOfYear(x: Date): number;
+  export = dayOfYear;
+}


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is no longer supported. `TypeError`s are
now thrown instead of being returned.